### PR TITLE
Add Next.js base config

### DIFF
--- a/realstate-mvp/next.config.ts
+++ b/realstate-mvp/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from 'next';
+
+const nextConfig: NextConfig = {
+  reactStrictMode: true,
+};
+
+export default nextConfig;

--- a/realstate-mvp/package.json
+++ b/realstate-mvp/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "realstate-mvp",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "prisma": "prisma"
+  },
+  "dependencies": {
+    "next": "15.3.4",
+    "react": "19.0.0",
+    "react-dom": "19.0.0",
+    "next-auth": "^4.24.11",
+    "@prisma/client": "^6.10.1",
+    "prisma": "^6.10.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "typescript": "^5",
+    "tailwindcss": "^3.4.0",
+    "postcss": "^8.4.34",
+    "autoprefixer": "^10.4.0"
+  }
+}

--- a/realstate-mvp/tsconfig.json
+++ b/realstate-mvp/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- define dependencies and scripts for Next.js, Prisma and Tailwind in `package.json`
- configure TypeScript compiler options in `tsconfig.json`
- enable strict mode in `next.config.ts`

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68588e5de6748321a7d522406ac94e99