### PR TITLE
Implement properties API with Prisma

### DIFF
--- a/realstate-mvp/src/app/api/properties/[id]/route.ts
+++ b/realstate-mvp/src/app/api/properties/[id]/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from 'next/server';
+import prisma from '../../../../lib/prisma';
+
+export async function GET(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  const id = Number(params.id);
+  try {
+    const property = await prisma.property.findUnique({
+      where: { id },
+      include: { photos: true, wholesalers: true },
+    });
+    if (!property) {
+      return NextResponse.json({ error: 'Property not found' }, { status: 404 });
+    }
+    return NextResponse.json(property);
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+export async function PUT(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  const id = Number(params.id);
+  try {
+    const data = await request.json();
+    const property = await prisma.property.update({
+      where: { id },
+      data,
+    });
+    return NextResponse.json(property);
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  const id = Number(params.id);
+  try {
+    await prisma.property.delete({ where: { id } });
+    return NextResponse.json({});
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/realstate-mvp/src/app/api/properties/route.ts
+++ b/realstate-mvp/src/app/api/properties/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+import prisma from '../../../lib/prisma';
+
+export async function GET() {
+  try {
+    const properties = await prisma.property.findMany({
+      include: { photos: true, wholesalers: true },
+    });
+    return NextResponse.json(properties);
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const data = await request.json();
+    const { address } = data;
+    const property = await prisma.property.create({ data: { address } });
+    return NextResponse.json(property, { status: 201 });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/realstate-mvp/src/lib/prisma.ts
+++ b/realstate-mvp/src/lib/prisma.ts
@@ -1,0 +1,13 @@
+import { PrismaClient } from '@prisma/client';
+
+const globalForPrisma = globalThis as unknown as {
+  prisma: PrismaClient | undefined;
+};
+
+export const prisma =
+  globalForPrisma.prisma ??
+  new PrismaClient({ log: ['query', 'error', 'warn'] });
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;
+
+export default prisma;


### PR DESCRIPTION
## Summary
- add Prisma client helper
- implement `/api/properties` GET/POST
- implement `/api/properties/[id]` GET/PUT/DELETE

## Testing
- `npm install`
- `npx prisma generate` *(fails: binaries.prisma.sh blocked)*
- `npm run build` *(fails: Next.js build worker exited)*

------
https://chatgpt.com/codex/tasks/task_e_68588f655d788321994b89590265cf79