### PR TITLE
Add Next.js property pages and admin auth

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -20,3 +20,14 @@ npx prisma generate
 ```
 
 El primer comando aplica las migraciones y crea la base de datos. El segundo genera el cliente de Prisma en `node_modules`. Luego podrás usarlo en la aplicación.
+
+## Variables de entorno para autenticación
+
+Para acceder al panel de administración necesitas definir un usuario y contraseña. Agrega en el archivo `.env` las siguientes variables:
+
+```
+ADMIN_USER=admin
+ADMIN_PASS=secret
+```
+
+Puedes cambiar los valores según prefieras.

--- a/realstate-mvp/src/app/[id]/page.tsx
+++ b/realstate-mvp/src/app/[id]/page.tsx
@@ -1,0 +1,32 @@
+import { notFound } from 'next/navigation';
+import type { Property } from '../types';
+
+async function getProperty(id: string): Promise<Property | null> {
+  const res = await fetch(`/api/properties/${id}`, { cache: 'no-store' });
+  if (!res.ok) return null;
+  return res.json();
+}
+
+export default async function PropertyPage({ params }: any) {
+  const property = await getProperty(params.id);
+  if (!property) notFound();
+
+  return (
+    <main className="p-4">
+      <h1 className="text-2xl font-bold mb-4">{property.address}</h1>
+      {property.photos?.map((photo) => (
+        <img key={photo.id} src={photo.url} alt="" className="mb-2 max-w-md" />
+      ))}
+      {property.wholesalers && (
+        <div>
+          <h2 className="font-semibold mt-4">Wholesalers</h2>
+          <ul className="list-disc pl-5">
+            {property.wholesalers.map((w) => (
+              <li key={w.id}>{w.name}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/realstate-mvp/src/app/admin/create/page.tsx
+++ b/realstate-mvp/src/app/admin/create/page.tsx
@@ -1,0 +1,49 @@
+'use client';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useSession, signIn } from 'next-auth/react';
+
+export default function CreatePropertyPage() {
+  const { data: session, status } = useSession();
+  const router = useRouter();
+  const [address, setAddress] = useState('');
+
+  if (status === 'loading') return <p>Loading...</p>;
+  if (!session) {
+    return (
+      <div className="p-4">
+        <p>You must be signed in to access this page.</p>
+        <button onClick={() => signIn()} className="underline text-blue-600">
+          Sign in
+        </button>
+      </div>
+    );
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const res = await fetch('/api/properties', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ address }),
+    });
+    if (res.ok) router.push('/');
+  }
+
+  return (
+    <main className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Create Property</h1>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-2 max-w-sm">
+        <input
+          className="border p-2"
+          placeholder="Address"
+          value={address}
+          onChange={(e) => setAddress(e.target.value)}
+        />
+        <button className="bg-blue-500 text-white p-2" type="submit">
+          Save
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/realstate-mvp/src/app/admin/edit/[id]/page.tsx
+++ b/realstate-mvp/src/app/admin/edit/[id]/page.tsx
@@ -1,0 +1,54 @@
+'use client';
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useSession, signIn } from 'next-auth/react';
+
+export default function EditPropertyPage({ params }: any) {
+  const { data: session, status } = useSession();
+  const router = useRouter();
+  const [address, setAddress] = useState('');
+
+  useEffect(() => {
+    fetch(`/api/properties/${params.id}`)
+      .then((res) => res.json())
+      .then((data) => setAddress(data.address));
+  }, [params.id]);
+
+  if (status === 'loading') return <p>Loading...</p>;
+  if (!session) {
+    return (
+      <div className="p-4">
+        <p>You must be signed in to access this page.</p>
+        <button onClick={() => signIn()} className="underline text-blue-600">
+          Sign in
+        </button>
+      </div>
+    );
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    await fetch(`/api/properties/${params.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ address }),
+    });
+    router.push(`/${params.id}`);
+  }
+
+  return (
+    <main className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Edit Property</h1>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-2 max-w-sm">
+        <input
+          className="border p-2"
+          value={address}
+          onChange={(e) => setAddress(e.target.value)}
+        />
+        <button className="bg-blue-500 text-white p-2" type="submit">
+          Update
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/realstate-mvp/src/app/admin/layout.tsx
+++ b/realstate-mvp/src/app/admin/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react';
+
+export default function AdminLayout({ children }: { children: ReactNode }) {
+  return (
+    <main className="p-4">
+      {children}
+    </main>
+  );
+}

--- a/realstate-mvp/src/app/admin/page.tsx
+++ b/realstate-mvp/src/app/admin/page.tsx
@@ -1,0 +1,8 @@
+export default function AdminHome() {
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">Admin</h1>
+      <p>Select an action from the menu.</p>
+    </div>
+  );
+}

--- a/realstate-mvp/src/app/api/auth/[...nextauth]/route.ts
+++ b/realstate-mvp/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,26 @@
+import NextAuth from 'next-auth';
+import CredentialsProvider from 'next-auth/providers/credentials';
+
+const handler = NextAuth({
+  providers: [
+    CredentialsProvider({
+      name: 'Credentials',
+      credentials: {
+        username: { label: 'Username', type: 'text' },
+        password: { label: 'Password', type: 'password' },
+      },
+      async authorize(credentials) {
+        if (
+          credentials?.username === process.env.ADMIN_USER &&
+          credentials?.password === process.env.ADMIN_PASS
+        ) {
+          return { id: '1', name: 'Admin' };
+        }
+        return null;
+      },
+    }),
+  ],
+  session: { strategy: 'jwt' },
+});
+
+export { handler as GET, handler as POST };

--- a/realstate-mvp/src/app/api/properties/[id]/route.ts
+++ b/realstate-mvp/src/app/api/properties/[id]/route.ts
@@ -1,10 +1,7 @@
 import { NextResponse } from 'next/server';
 import prisma from '../../../../lib/prisma';
 
-export async function GET(
-  request: Request,
-  { params }: { params: { id: string } }
-) {
+export async function GET(request: Request, { params }: any) {
   const id = Number(params.id);
   try {
     const property = await prisma.property.findUnique({
@@ -21,10 +18,7 @@ export async function GET(
   }
 }
 
-export async function PUT(
-  request: Request,
-  { params }: { params: { id: string } }
-) {
+export async function PUT(request: Request, { params }: any) {
   const id = Number(params.id);
   try {
     const data = await request.json();
@@ -39,10 +33,7 @@ export async function PUT(
   }
 }
 
-export async function DELETE(
-  request: Request,
-  { params }: { params: { id: string } }
-) {
+export async function DELETE(request: Request, { params }: any) {
   const id = Number(params.id);
   try {
     await prisma.property.delete({ where: { id } });

--- a/realstate-mvp/src/app/global.css
+++ b/realstate-mvp/src/app/global.css
@@ -1,0 +1,9 @@
+body {
+  font-family: sans-serif;
+  margin: 0;
+  padding: 0;
+}
+
+input, button {
+  font-size: 1rem;
+}

--- a/realstate-mvp/src/app/layout.tsx
+++ b/realstate-mvp/src/app/layout.tsx
@@ -1,0 +1,13 @@
+import './global.css';
+import { SessionProvider } from 'next-auth/react';
+import type { ReactNode } from 'react';
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <SessionProvider>{children}</SessionProvider>
+      </body>
+    </html>
+  );
+}

--- a/realstate-mvp/src/app/page.tsx
+++ b/realstate-mvp/src/app/page.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import type { Property } from './types';
+
+export default function HomePage() {
+  const [properties, setProperties] = useState<Property[]>([]);
+  const [search, setSearch] = useState('');
+
+  useEffect(() => {
+    fetch('/api/properties')
+      .then((res) => res.json())
+      .then(setProperties)
+      .catch(console.error);
+  }, []);
+
+  const filtered = properties.filter((p) =>
+    p.address.toLowerCase().includes(search.toLowerCase())
+  );
+
+  return (
+    <main className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Properties</h1>
+      <input
+        className="border p-2 mb-4"
+        placeholder="Filter by address"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+      />
+      <ul className="list-disc pl-5">
+        {filtered.map((p) => (
+          <li key={p.id} className="mb-2">
+            <Link href={`/${p.id}`}>{p.address}</Link>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/realstate-mvp/src/app/types.ts
+++ b/realstate-mvp/src/app/types.ts
@@ -1,0 +1,6 @@
+export interface Property {
+  id: number;
+  address: string;
+  photos?: { id: number; url: string }[];
+  wholesalers?: { id: number; name: string }[];
+}


### PR DESCRIPTION
## Summary
- implement home page listing properties with filter
- add property detail route
- add admin section with forms for create/edit
- secure admin pages using NextAuth credentials provider
- document environment variables for admin user

## Testing
- `npm run build` *(fails: @prisma/client not generated)*
- `npx prisma generate` *(fails: binaries.prisma.sh blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6858905271488321a3426a389feb323f