### PR TITLE
Expand property fields

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,6 +10,13 @@ generator client {
 model Property {
   id          Int          @id @default(autoincrement())
   address     String
+  city        String?
+  state       String?
+  zip         String?
+  county      String?
+  price       Int?
+  beds        Int?
+  baths       Float?
   photos      Photo[]
   wholesalers Wholesaler[] @relation("PropertyWholesalers")
 }

--- a/src/app/admin/create/page.tsx
+++ b/src/app/admin/create/page.tsx
@@ -7,6 +7,13 @@ export default function CreatePropertyPage() {
   const { data: session, status } = useSession();
   const router = useRouter();
   const [address, setAddress] = useState('');
+  const [city, setCity] = useState('');
+  const [stateVal, setStateVal] = useState('');
+  const [zip, setZip] = useState('');
+  const [county, setCounty] = useState('');
+  const [price, setPrice] = useState('');
+  const [beds, setBeds] = useState('');
+  const [baths, setBaths] = useState('');
 
   if (status === 'loading') return <p>Loading...</p>;
   if (!session) {
@@ -25,7 +32,16 @@ export default function CreatePropertyPage() {
     const res = await fetch('/api/properties', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ address }),
+      body: JSON.stringify({
+        address,
+        city,
+        state: stateVal,
+        zip,
+        county,
+        price: price ? Number(price) : null,
+        beds: beds ? Number(beds) : null,
+        baths: baths ? parseFloat(baths) : null,
+      }),
     });
     if (res.ok) router.push('/');
   }
@@ -39,6 +55,52 @@ export default function CreatePropertyPage() {
           placeholder="Address"
           value={address}
           onChange={(e) => setAddress(e.target.value)}
+        />
+        <input
+          className="border p-2"
+          placeholder="City"
+          value={city}
+          onChange={(e) => setCity(e.target.value)}
+        />
+        <input
+          className="border p-2"
+          placeholder="State"
+          value={stateVal}
+          onChange={(e) => setStateVal(e.target.value)}
+        />
+        <input
+          className="border p-2"
+          placeholder="ZIP"
+          value={zip}
+          onChange={(e) => setZip(e.target.value)}
+        />
+        <input
+          className="border p-2"
+          placeholder="County"
+          value={county}
+          onChange={(e) => setCounty(e.target.value)}
+        />
+        <input
+          className="border p-2"
+          placeholder="Price"
+          type="number"
+          value={price}
+          onChange={(e) => setPrice(e.target.value)}
+        />
+        <input
+          className="border p-2"
+          placeholder="Beds"
+          type="number"
+          value={beds}
+          onChange={(e) => setBeds(e.target.value)}
+        />
+        <input
+          className="border p-2"
+          placeholder="Baths"
+          type="number"
+          step="0.5"
+          value={baths}
+          onChange={(e) => setBaths(e.target.value)}
         />
         <button className="bg-blue-500 text-white p-2" type="submit">
           Save

--- a/src/app/admin/edit/[id]/page.tsx
+++ b/src/app/admin/edit/[id]/page.tsx
@@ -7,11 +7,27 @@ export default function EditPropertyPage({ params }: any) {
   const { data: session, status } = useSession();
   const router = useRouter();
   const [address, setAddress] = useState('');
+  const [city, setCity] = useState('');
+  const [stateVal, setStateVal] = useState('');
+  const [zip, setZip] = useState('');
+  const [county, setCounty] = useState('');
+  const [price, setPrice] = useState('');
+  const [beds, setBeds] = useState('');
+  const [baths, setBaths] = useState('');
 
   useEffect(() => {
     fetch(`/api/properties/${params.id}`)
       .then((res) => res.json())
-      .then((data) => setAddress(data.address));
+      .then((data) => {
+        setAddress(data.address || '');
+        setCity(data.city || '');
+        setStateVal(data.state || '');
+        setZip(data.zip || '');
+        setCounty(data.county || '');
+        setPrice(data.price ?? '');
+        setBeds(data.beds ?? '');
+        setBaths(data.baths ?? '');
+      });
   }, [params.id]);
 
   if (status === 'loading') return <p>Loading...</p>;
@@ -31,7 +47,16 @@ export default function EditPropertyPage({ params }: any) {
     await fetch(`/api/properties/${params.id}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ address }),
+      body: JSON.stringify({
+        address,
+        city,
+        state: stateVal,
+        zip,
+        county,
+        price: price ? Number(price) : null,
+        beds: beds ? Number(beds) : null,
+        baths: baths ? parseFloat(baths) : null,
+      }),
     });
     router.push(`/${params.id}`);
   }
@@ -44,6 +69,52 @@ export default function EditPropertyPage({ params }: any) {
           className="border p-2"
           value={address}
           onChange={(e) => setAddress(e.target.value)}
+        />
+        <input
+          className="border p-2"
+          placeholder="City"
+          value={city}
+          onChange={(e) => setCity(e.target.value)}
+        />
+        <input
+          className="border p-2"
+          placeholder="State"
+          value={stateVal}
+          onChange={(e) => setStateVal(e.target.value)}
+        />
+        <input
+          className="border p-2"
+          placeholder="ZIP"
+          value={zip}
+          onChange={(e) => setZip(e.target.value)}
+        />
+        <input
+          className="border p-2"
+          placeholder="County"
+          value={county}
+          onChange={(e) => setCounty(e.target.value)}
+        />
+        <input
+          className="border p-2"
+          placeholder="Price"
+          type="number"
+          value={price}
+          onChange={(e) => setPrice(e.target.value)}
+        />
+        <input
+          className="border p-2"
+          placeholder="Beds"
+          type="number"
+          value={beds}
+          onChange={(e) => setBeds(e.target.value)}
+        />
+        <input
+          className="border p-2"
+          placeholder="Baths"
+          type="number"
+          step="0.5"
+          value={baths}
+          onChange={(e) => setBaths(e.target.value)}
         />
         <button className="bg-blue-500 text-white p-2" type="submit">
           Update

--- a/src/app/api/properties/[id]/route.ts
+++ b/src/app/api/properties/[id]/route.ts
@@ -22,9 +22,19 @@ export async function PUT(request: Request, { params }: any) {
   const id = Number(params.id);
   try {
     const data = await request.json();
+    const {
+      address,
+      city,
+      state,
+      zip,
+      county,
+      price,
+      beds,
+      baths,
+    } = data;
     const property = await prisma.property.update({
       where: { id },
-      data,
+      data: { address, city, state, zip, county, price, beds, baths },
     });
     return NextResponse.json(property);
   } catch (error) {

--- a/src/app/api/properties/route.ts
+++ b/src/app/api/properties/route.ts
@@ -16,8 +16,19 @@ export async function GET() {
 export async function POST(request: Request) {
   try {
     const data = await request.json();
-    const { address } = data;
-    const property = await prisma.property.create({ data: { address } });
+    const {
+      address,
+      city,
+      state,
+      zip,
+      county,
+      price,
+      beds,
+      baths,
+    } = data;
+    const property = await prisma.property.create({
+      data: { address, city, state, zip, county, price, beds, baths },
+    });
     return NextResponse.json(property, { status: 201 });
   } catch (error) {
     console.error(error);

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -1,6 +1,13 @@
 export interface Property {
   id: number;
   address: string;
+  city?: string | null;
+  state?: string | null;
+  zip?: string | null;
+  county?: string | null;
+  price?: number | null;
+  beds?: number | null;
+  baths?: number | null;
   photos?: { id: number; url: string }[];
   wholesalers?: { id: number; name: string }[];
 }


### PR DESCRIPTION
## Summary
- allow city, state, zip, county, price and bed/bath info in the DB
- capture the new fields when creating or editing properties
- expose new fields from the API
- update TypeScript `Property` type

## Testing
- `npm run build` *(fails: Can't resolve '../next-i18next.config.js')*
- `npx prisma migrate dev --name add-fields` *(fails: 403 Forbidden fetching Prisma engines)*

------
https://chatgpt.com/codex/tasks/task_e_68589d45be9c83218d75f034e1c05ca8