### PR TITLE
Add photo upload support

### DIFF
--- a/src/app/admin/create/page.tsx
+++ b/src/app/admin/create/page.tsx
@@ -14,6 +14,7 @@ export default function CreatePropertyPage() {
   const [price, setPrice] = useState('');
   const [beds, setBeds] = useState('');
   const [baths, setBaths] = useState('');
+  const [files, setFiles] = useState<FileList | null>(null);
 
   if (status === 'loading') return <p>Loading...</p>;
   if (!session) {
@@ -43,7 +44,18 @@ export default function CreatePropertyPage() {
         baths: baths ? parseFloat(baths) : null,
       }),
     });
-    if (res.ok) router.push('/');
+    if (res.ok) {
+      const property = await res.json();
+      if (files) {
+        for (const file of Array.from(files)) {
+          const fd = new FormData();
+          fd.append('file', file);
+          fd.append('propertyId', property.id.toString());
+          await fetch('/api/upload', { method: 'POST', body: fd });
+        }
+      }
+      router.push('/');
+    }
   }
 
   return (
@@ -101,6 +113,12 @@ export default function CreatePropertyPage() {
           step="0.5"
           value={baths}
           onChange={(e) => setBaths(e.target.value)}
+        />
+        <input
+          className="border p-2"
+          type="file"
+          multiple
+          onChange={(e) => setFiles(e.target.files)}
         />
         <button className="bg-blue-500 text-white p-2" type="submit">
           Save

--- a/src/app/admin/edit/[id]/page.tsx
+++ b/src/app/admin/edit/[id]/page.tsx
@@ -14,6 +14,7 @@ export default function EditPropertyPage({ params }: any) {
   const [price, setPrice] = useState('');
   const [beds, setBeds] = useState('');
   const [baths, setBaths] = useState('');
+  const [files, setFiles] = useState<FileList | null>(null);
 
   useEffect(() => {
     fetch(`/api/properties/${params.id}`)
@@ -44,7 +45,7 @@ export default function EditPropertyPage({ params }: any) {
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    await fetch(`/api/properties/${params.id}`, {
+    const res = await fetch(`/api/properties/${params.id}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -58,7 +59,17 @@ export default function EditPropertyPage({ params }: any) {
         baths: baths ? parseFloat(baths) : null,
       }),
     });
-    router.push(`/${params.id}`);
+    if (res.ok) {
+      if (files) {
+        for (const file of Array.from(files)) {
+          const fd = new FormData();
+          fd.append('file', file);
+          fd.append('propertyId', params.id);
+          await fetch('/api/upload', { method: 'POST', body: fd });
+        }
+      }
+      router.push(`/${params.id}`);
+    }
   }
 
   return (
@@ -115,6 +126,12 @@ export default function EditPropertyPage({ params }: any) {
           step="0.5"
           value={baths}
           onChange={(e) => setBaths(e.target.value)}
+        />
+        <input
+          className="border p-2"
+          type="file"
+          multiple
+          onChange={(e) => setFiles(e.target.files)}
         />
         <button className="bg-blue-500 text-white p-2" type="submit">
           Update

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server';
+import { writeFile, mkdir } from 'fs/promises';
+import path from 'path';
+import prisma from '../../../lib/prisma';
+
+export async function POST(request: Request) {
+  const formData = await request.formData();
+  const file = formData.get('file');
+  if (!file || !(file instanceof File)) {
+    return NextResponse.json({ error: 'File missing' }, { status: 400 });
+  }
+  const propertyId = formData.get('propertyId');
+  const bytes = await file.arrayBuffer();
+  const buffer = Buffer.from(bytes);
+  const uploadsDir = path.join(process.cwd(), 'public', 'uploads');
+  await mkdir(uploadsDir, { recursive: true });
+  const filename = `${Date.now()}-${file.name}`;
+  await writeFile(path.join(uploadsDir, filename), buffer);
+  const url = `/uploads/${filename}`;
+  const data: any = { url };
+  if (propertyId) data.propertyId = Number(propertyId);
+  const photo = await prisma.photo.create({ data });
+  return NextResponse.json(photo, { status: 201 });
+}


### PR DESCRIPTION
## Summary
- create photo upload API route
- add file input handling in create & edit property forms
- store uploaded photos via new endpoint

## Testing
- `npm run build` *(fails: Module not found '../next-i18next.config.js')*

------
https://chatgpt.com/codex/tasks/task_e_68589e7e6e508321affcced9a3a055ca