### PR TITLE
Add server-side property filtering

### DIFF
--- a/src/app/api/properties/route.ts
+++ b/src/app/api/properties/route.ts
@@ -1,9 +1,37 @@
 import { NextResponse } from 'next/server';
 import prisma from '../../../lib/prisma';
 
-export async function GET() {
+export async function GET(request: Request) {
   try {
+    const { searchParams } = new URL(request.url);
+
+    const where: any = {};
+
+    const address = searchParams.get('address');
+    if (address) where.address = { contains: address, mode: 'insensitive' };
+
+    const city = searchParams.get('city');
+    if (city) where.city = { contains: city, mode: 'insensitive' };
+
+    const county = searchParams.get('county');
+    if (county) where.county = { contains: county, mode: 'insensitive' };
+
+    const minPrice = parseInt(searchParams.get('minPrice') || '');
+    const maxPrice = parseInt(searchParams.get('maxPrice') || '');
+    if (!isNaN(minPrice) || !isNaN(maxPrice)) {
+      where.price = {};
+      if (!isNaN(minPrice)) where.price.gte = minPrice;
+      if (!isNaN(maxPrice)) where.price.lte = maxPrice;
+    }
+
+    const beds = parseInt(searchParams.get('beds') || '');
+    if (!isNaN(beds)) where.beds = { gte: beds };
+
+    const baths = parseFloat(searchParams.get('baths') || '');
+    if (!isNaN(baths)) where.baths = { gte: baths };
+
     const properties = await prisma.property.findMany({
+      where,
       include: { photos: true, wholesalers: true },
     });
     return NextResponse.json(properties);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,29 +7,83 @@ import type { Property } from './types';
 export default function HomePage() {
   const [properties, setProperties] = useState<Property[]>([]);
   const [search, setSearch] = useState('');
+  const [city, setCity] = useState('');
+  const [county, setCounty] = useState('');
+  const [minPrice, setMinPrice] = useState('');
+  const [maxPrice, setMaxPrice] = useState('');
+  const [beds, setBeds] = useState('');
+  const [baths, setBaths] = useState('');
 
   useEffect(() => {
-    fetch('/api/properties')
+    const params = new URLSearchParams();
+    if (search) params.set('address', search);
+    if (city) params.set('city', city);
+    if (county) params.set('county', county);
+    if (minPrice) params.set('minPrice', minPrice);
+    if (maxPrice) params.set('maxPrice', maxPrice);
+    if (beds) params.set('beds', beds);
+    if (baths) params.set('baths', baths);
+
+    fetch(`/api/properties?${params.toString()}`)
       .then((res) => res.json())
       .then(setProperties)
       .catch(console.error);
-  }, []);
-
-  const filtered = properties.filter((p) =>
-    p.address.toLowerCase().includes(search.toLowerCase())
-  );
+  }, [search, city, county, minPrice, maxPrice, beds, baths]);
 
   return (
     <main className="p-4">
       <h1 className="text-2xl font-bold mb-4">Properties</h1>
-      <input
-        className="border p-2 mb-4"
-        placeholder="Filter by address"
-        value={search}
-        onChange={(e) => setSearch(e.target.value)}
-      />
+      <div className="flex flex-col gap-2 mb-4 max-w-md">
+        <input
+          className="border p-2"
+          placeholder="Address"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        <input
+          className="border p-2"
+          placeholder="City"
+          value={city}
+          onChange={(e) => setCity(e.target.value)}
+        />
+        <input
+          className="border p-2"
+          placeholder="County"
+          value={county}
+          onChange={(e) => setCounty(e.target.value)}
+        />
+        <input
+          className="border p-2"
+          type="number"
+          placeholder="Min Price"
+          value={minPrice}
+          onChange={(e) => setMinPrice(e.target.value)}
+        />
+        <input
+          className="border p-2"
+          type="number"
+          placeholder="Max Price"
+          value={maxPrice}
+          onChange={(e) => setMaxPrice(e.target.value)}
+        />
+        <input
+          className="border p-2"
+          type="number"
+          placeholder="Beds"
+          value={beds}
+          onChange={(e) => setBeds(e.target.value)}
+        />
+        <input
+          className="border p-2"
+          type="number"
+          step="0.5"
+          placeholder="Baths"
+          value={baths}
+          onChange={(e) => setBaths(e.target.value)}
+        />
+      </div>
       <ul className="list-disc pl-5">
-        {filtered.map((p) => (
+        {properties.map((p) => (
           <li key={p.id} className="mb-2">
             <Link href={`/${p.id}`}>{p.address}</Link>
           </li>


### PR DESCRIPTION
## Summary
- expand the property search UI with more filters
- accept filtering query params in the properties API
- send filter params from client when requesting properties

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_68589f5bb7f88321957241d3e2ee37be