### PR TITLE
Fix i18n setup and TS config

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next-i18next.config.js
+++ b/next-i18next.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  i18n: {
+    defaultLocale: 'en',
+    locales: ['en', 'es'],
+    localePath: './public/locales',
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       },
       "devDependencies": {
         "@types/node": "^20",
+        "@types/pg": "^8.15.4",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "autoprefixer": "^10.4.0",
@@ -825,6 +826,18 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.15.4",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.15.4.tgz",
+      "integrity": "sha512-I6UNVBAoYbvuWkkU3oosC8yxqH21f4/Jc4DK71JLG3dT2mdlGe1z+ep/LQGXaKaOgcvUrsQoPRqfgtMcvZiJhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
       }
     },
     "node_modules/@types/phoenix": {

--- a/package.json
+++ b/package.json
@@ -8,23 +8,24 @@
     "start": "next start"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.39.5",
+    "i18next": "^25.2.1",
     "next": "15.3.4",
-    "react": "19.0.0",
-    "react-dom": "19.0.0",
     "next-auth": "^4.24.11",
     "next-i18next": "^15.4.2",
-    "i18next": "^25.2.1",
-    "react-i18next": "^15.5.3",
-    "@supabase/supabase-js": "^2.39.5",
-    "pg": "^8.11.2"
+    "pg": "^8.11.2",
+    "react": "19.0.0",
+    "react-dom": "19.0.0",
+    "react-i18next": "^15.5.3"
   },
   "devDependencies": {
     "@types/node": "^20",
+    "@types/pg": "^8.15.4",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "typescript": "^5",
-    "tailwindcss": "^3.4.0",
+    "autoprefixer": "^10.4.0",
     "postcss": "^8.4.34",
-    "autoprefixer": "^10.4.0"
+    "tailwindcss": "^3.4.0",
+    "typescript": "^5"
   }
 }

--- a/src/app/components/LanguageSwitcher.tsx
+++ b/src/app/components/LanguageSwitcher.tsx
@@ -3,7 +3,8 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useTranslation } from 'next-i18next';
-import i18nConfig from '../../next-i18next.config.js';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const i18nConfig = require('../../next-i18next.config.js');
 
 const { locales } = i18nConfig.i18n;
 
@@ -13,7 +14,7 @@ export default function LanguageSwitcher() {
 
   return (
     <div className="space-x-2">
-      {locales.map((lng) => (
+      {locales.map((lng: string) => (
         <Link key={lng} href={pathname} locale={lng} prefetch={false}>
           <span className={i18n.language === lng ? 'font-bold' : ''}>
             {lng.toUpperCase()}

--- a/src/app/i18n.tsx
+++ b/src/app/i18n.tsx
@@ -2,10 +2,13 @@
 
 import { appWithTranslation } from 'next-i18next';
 import type { ReactNode } from 'react';
-import nextI18NextConfig from '../next-i18next.config.js';
+import nextI18NextConfig from '../../next-i18next.config.js';
 
 function I18nProvider({ children }: { children: ReactNode }) {
   return <>{children}</>;
 }
 
-export default appWithTranslation(I18nProvider, nextI18NextConfig);
+export default appWithTranslation(
+  I18nProvider as any,
+  nextI18NextConfig as any,
+) as any;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,4 @@
+"use client";
 import './global.css';
 import { SessionProvider } from 'next-auth/react';
 import type { ReactNode } from 'react';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -13,8 +17,20 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- add next-i18next configuration
- import the config correctly in i18n provider and language switcher
- mark layout as a client component
- install `@types/pg` and update tsconfig

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685898c1272c832188e9e10b66acdeaf