### PR TITLE
Add admin check on Save button

### DIFF
--- a/src/app/admin/create/page.tsx
+++ b/src/app/admin/create/page.tsx
@@ -5,6 +5,7 @@ import { useSession, signIn } from 'next-auth/react';
 
 export default function CreatePropertyPage() {
   const { data: session, status } = useSession();
+  const isAdmin = session?.user?.name === 'Admin';
   const router = useRouter();
   const [address, setAddress] = useState('');
   const [city, setCity] = useState('');
@@ -123,12 +124,14 @@ export default function CreatePropertyPage() {
           multiple
           onChange={(e) => setFiles(e.target.files)}
         />
-        <button
-          className="bg-blue-500 text-white p-2 md:col-span-2"
-          type="submit"
-        >
-          Save
-        </button>
+        {isAdmin && (
+          <button
+            className="bg-blue-500 text-white p-2 md:col-span-2"
+            type="submit"
+          >
+            Save
+          </button>
+        )}
       </form>
     </main>
   );

--- a/src/app/admin/edit/[id]/page.tsx
+++ b/src/app/admin/edit/[id]/page.tsx
@@ -5,6 +5,7 @@ import { useSession, signIn } from 'next-auth/react';
 
 export default function EditPropertyPage({ params }: any) {
   const { data: session, status } = useSession();
+  const isAdmin = session?.user?.name === 'Admin';
   const router = useRouter();
   const [address, setAddress] = useState('');
   const [city, setCity] = useState('');
@@ -136,12 +137,14 @@ export default function EditPropertyPage({ params }: any) {
           multiple
           onChange={(e) => setFiles(e.target.files)}
         />
-        <button
-          className="bg-blue-500 text-white p-2 md:col-span-2"
-          type="submit"
-        >
-          Save
-        </button>
+        {isAdmin && (
+          <button
+            className="bg-blue-500 text-white p-2 md:col-span-2"
+            type="submit"
+          >
+            Save
+          </button>
+        )}
       </form>
     </main>
   );


### PR DESCRIPTION
## Summary
- show Save button in admin create and edit pages only for Admin users

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685912aeade08321a299173d2bc7d82a