### PR TITLE
Add image carousel and show admin save button

### DIFF
--- a/src/app/[id]/page.tsx
+++ b/src/app/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from 'next/navigation';
 import type { Property } from '../types';
 import { getPropertyById } from '../../lib/db';
+import PhotoCarousel from '../components/PhotoCarousel';
 
 export default async function PropertyPage({ params }: any) {
   const id = Number(params.id);
@@ -11,27 +12,32 @@ export default async function PropertyPage({ params }: any) {
   return (
     <main className="p-4">
       <h1 className="text-2xl font-bold mb-4">{property.address}</h1>
-      <div className="grid gap-4 md:grid-cols-2">
-        <div>
-          {property.photos?.map((photo) => (
-            <img
-              key={photo.id}
-              src={photo.url}
-              alt=""
-              className="mb-2 w-full object-cover"
-            />
-          ))}
+      <div className="grid gap-6 md:grid-cols-2">
+        <PhotoCarousel
+          urls={property.photos?.map((p) => p.url) ?? []}
+        />
+        <div className="space-y-2">
+          <p>
+            {[property.city, property.state, property.zip]
+              .filter(Boolean)
+              .join(', ')}
+          </p>
+          {property.county && <p>County: {property.county}</p>}
+          {property.price && <p className="font-semibold">Price: ${property.price}</p>}
+          {property.beds != null && <p>Beds: {property.beds}</p>}
+          {property.baths != null && <p>Baths: {property.baths}</p>}
+
+          {property.wholesalers && (
+            <div>
+              <h2 className="font-semibold">Wholesalers</h2>
+              <ul className="list-disc pl-5">
+                {property.wholesalers.map((w) => (
+                  <li key={w.id}>{w.name}</li>
+                ))}
+              </ul>
+            </div>
+          )}
         </div>
-        {property.wholesalers && (
-          <div>
-            <h2 className="font-semibold mt-4 md:mt-0">Wholesalers</h2>
-            <ul className="list-disc pl-5">
-              {property.wholesalers.map((w) => (
-                <li key={w.id}>{w.name}</li>
-              ))}
-            </ul>
-          </div>
-        )}
       </div>
     </main>
   );

--- a/src/app/admin/create/page.tsx
+++ b/src/app/admin/create/page.tsx
@@ -5,6 +5,7 @@ import { useSession, signIn } from 'next-auth/react';
 
 export default function CreatePropertyPage() {
   const { data: session, status } = useSession();
+  const isAdmin = session?.user?.name === 'Admin';
   const router = useRouter();
   const [address, setAddress] = useState('');
   const [city, setCity] = useState('');
@@ -123,12 +124,14 @@ export default function CreatePropertyPage() {
           multiple
           onChange={(e) => setFiles(e.target.files)}
         />
-        <button
-          className="bg-blue-500 text-white p-2 md:col-span-2"
-          type="submit"
-        >
-          Save
-        </button>
+        {isAdmin && (
+          <button
+            className="bg-blue-500 text-white p-2 md:col-span-2"
+            type="submit"
+          >
+            Save
+          </button>
+        )}
       </form>
     </main>
   );

--- a/src/app/admin/edit/[id]/page.tsx
+++ b/src/app/admin/edit/[id]/page.tsx
@@ -5,6 +5,7 @@ import { useSession, signIn } from 'next-auth/react';
 
 export default function EditPropertyPage({ params }: any) {
   const { data: session, status } = useSession();
+  const isAdmin = session?.user?.name === 'Admin';
   const router = useRouter();
   const [address, setAddress] = useState('');
   const [city, setCity] = useState('');
@@ -136,12 +137,14 @@ export default function EditPropertyPage({ params }: any) {
           multiple
           onChange={(e) => setFiles(e.target.files)}
         />
-        <button
-          className="bg-blue-500 text-white p-2 md:col-span-2"
-          type="submit"
-        >
-          Save
-        </button>
+        {isAdmin && (
+          <button
+            className="bg-blue-500 text-white p-2 md:col-span-2"
+            type="submit"
+          >
+            Save
+          </button>
+        )}
       </form>
     </main>
   );

--- a/src/app/components/PhotoCarousel.tsx
+++ b/src/app/components/PhotoCarousel.tsx
@@ -1,0 +1,37 @@
+'use client';
+import { useState } from 'react';
+
+export default function PhotoCarousel({ urls }: { urls: string[] }) {
+  const [index, setIndex] = useState(0);
+  if (!urls.length) return null;
+
+  function prev() {
+    setIndex((i) => (i === 0 ? urls.length - 1 : i - 1));
+  }
+
+  function next() {
+    setIndex((i) => (i === urls.length - 1 ? 0 : i + 1));
+  }
+
+  return (
+    <div className="relative">
+      <img src={urls[index]} alt="" className="w-full h-64 object-cover" />
+      {urls.length > 1 && (
+        <div className="absolute inset-0 flex items-center justify-between px-2">
+          <button
+            onClick={prev}
+            className="bg-white/70 hover:bg-white text-gray-800 rounded-full px-2"
+          >
+            ◀
+          </button>
+          <button
+            onClick={next}
+            className="bg-white/70 hover:bg-white text-gray-800 rounded-full px-2"
+          >
+            ▶
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- display Save button in admin pages only for admins
- add a simple photo carousel and show full property details

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npm run build` *(fails: cannot find module in realstate-mvp subproject)*

------
https://chatgpt.com/codex/tasks/task_e_685912aeade08321a299173d2bc7d82a