### PR TITLE
Add Firebase connection example

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,6 @@
 This is a NextJS starter in Firebase Studio.
 
 To get started, take a look at src/app/page.tsx.
+
+For detalles sobre conectar la aplicaci\u00f3n a Firebase y c\u00f3mo almacenar
+las fotos de las propiedades, consulta [docs/firebase.md](docs/firebase.md).

--- a/docs/firebase.md
+++ b/docs/firebase.md
@@ -1,0 +1,26 @@
+# Firebase Connection
+
+Esta aplicaci\u00f3n usa [Firebase](https://firebase.google.com/) para persistir las propiedades y almacenar las fotos de cada inmueble.
+
+## Configuraci\u00f3n
+
+1. Crea un proyecto en Firebase y habilita Firestore y Storage.
+2. Obt\u00e9n las credenciales Web de tu proyecto y copia los valores en un archivo `.env` en la ra\u00edz del proyecto:
+
+```bash
+NEXT_PUBLIC_FIREBASE_API_KEY=your_api_key
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=your_auth_domain
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=your_project_id
+NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=your_storage_bucket
+NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=your_sender_id
+NEXT_PUBLIC_FIREBASE_APP_ID=your_app_id
+```
+
+3. Ejecuta el script `npm run test:firebase` para probar la conexi\u00f3n. Si la configuraci\u00f3n es correcta, deber\u00edas ver en consola el n\u00famero de propiedades registradas en la colecci\u00f3n `properties`.
+
+## Almacenamiento de datos y fotos
+
+- **Firestore**: cada documento en la colecci\u00f3n `properties` representa una casa y contiene datos como el t\u00edtulo, descripci\u00f3n, precio, ubicaci\u00f3n y amenidades.
+- **Firebase Storage**: las im\u00e1genes de las propiedades se guardan en el bucket configurado en `storageBucket`. Cada documento de Firestore guarda la URL p\u00fablica de la foto en el campo `imageUrl`.
+
+Con esta configuraci\u00f3n podr\u00e1s realizar operaciones de crear, leer, actualizar y eliminar propiedades y sus fotos.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test:firebase": "tsx scripts/test-firebase.ts"
   },
   "dependencies": {
     "@genkit-ai/googleai": "^1.8.0",

--- a/scripts/test-firebase.ts
+++ b/scripts/test-firebase.ts
@@ -1,0 +1,13 @@
+import 'dotenv/config';
+import { db } from '../src/lib/firebase';
+import { collection, getDocs } from 'firebase/firestore';
+
+async function run() {
+  const snapshot = await getDocs(collection(db, 'properties'));
+  console.log(`Found ${snapshot.size} properties`);
+}
+
+run().catch((err) => {
+  console.error('Firebase connection failed:', err.message);
+  process.exit(1);
+});

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from 'next/link';
-import { Home, Shield, UserSwitch } from 'lucide-react';
+import { Home, Shield } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,0 +1,17 @@
+import { initializeApp, getApps } from 'firebase/app';
+import { getFirestore } from 'firebase/firestore';
+import { getStorage } from 'firebase/storage';
+
+const firebaseConfig = {
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+};
+
+const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
+
+export const db = getFirestore(app);
+export const storage = getStorage(app);


### PR DESCRIPTION
## Summary
- add Firebase config helper and test script
- document how to connect and store property images
- mention Firebase docs in README

## Testing
- `npm run typecheck`
- `npm run build`
- `npm run test:firebase`


------
https://chatgpt.com/codex/tasks/task_e_6859221a50d08321bb64b2f81670dec7