### PR TITLE
Add Firebase image upload utility and form field

### DIFF
--- a/src/app/admin/property-form.tsx
+++ b/src/app/admin/property-form.tsx
@@ -2,6 +2,7 @@
 
 import * as z from 'zod';
 import { useForm } from 'react-hook-form';
+import { useState } from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useApp } from '@/context/app-provider';
 import { useRouter } from 'next/navigation';
@@ -14,6 +15,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Textarea } from '@/components/ui/textarea';
 import { Checkbox } from '@/components/ui/checkbox';
 import type { Property } from '@/lib/types';
+import { uploadImage } from '@/lib/storage';
 
 const formSchema = z.object({
   title: z.string().min(5, "Title must be at least 5 characters"),
@@ -43,6 +45,7 @@ export function PropertyForm({ property }: PropertyFormProps) {
   const router = useRouter();
   const { toast } = useToast();
   const isEditMode = !!property;
+  const [imageFile, setImageFile] = useState<File | null>(null);
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
@@ -70,7 +73,17 @@ export function PropertyForm({ property }: PropertyFormProps) {
     },
   });
 
-  function onSubmit(values: z.infer<typeof formSchema>) {
+  async function onSubmit(values: z.infer<typeof formSchema>) {
+    if (imageFile) {
+      try {
+        const url = await uploadImage(imageFile);
+        values.imageUrl = url;
+        form.setValue('imageUrl', url);
+      } catch (err) {
+        toast({ title: 'Upload failed', description: 'Image could not be uploaded' });
+        return;
+      }
+    }
     if (isEditMode) {
       updateProperty({ ...values, id: property.id });
       toast({ title: 'Property Updated!', description: 'The property details have been saved.' });
@@ -198,6 +211,14 @@ export function PropertyForm({ property }: PropertyFormProps) {
                     <FormMessage />
                 </FormItem>
             )} />
+
+            <FormItem>
+                <FormLabel>Upload Image</FormLabel>
+                <FormControl>
+                    <Input type="file" accept="image/*" onChange={(e) => setImageFile(e.target.files?.[0] || null)} />
+                </FormControl>
+                <FormDescription>The selected image will be uploaded to Firebase</FormDescription>
+            </FormItem>
 
              <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
                 <FormField control={form.control} name="agent.name" render={({ field }) => (

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,8 @@
+import { ref, uploadBytes, getDownloadURL } from 'firebase/storage'
+import { storage } from './firebase'
+
+export async function uploadImage(file: File): Promise<string> {
+  const storageRef = ref(storage, `properties/${Date.now()}_${file.name}`)
+  await uploadBytes(storageRef, file)
+  return getDownloadURL(storageRef)
+}


### PR DESCRIPTION
## Summary
- enable image uploads with Firebase Storage
- update property form to optionally upload images

## Testing
- `npm run typecheck` *(fails: Module '"lucide-react"' has no exported member 'UserSwitch')*
- `npm run lint` *(interactive prompt prevents execution)*
- `npm run test:firebase` *(fails to connect to firestore)*

------
https://chatgpt.com/codex/tasks/task_e_6859dc7086408321aaf537cfd71552df