### PR TITLE
Connect property creation to Firestore

### DIFF
--- a/src/app/admin/property-form.tsx
+++ b/src/app/admin/property-form.tsx
@@ -2,6 +2,7 @@
 
 import * as z from 'zod';
 import { useForm } from 'react-hook-form';
+import { useState } from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useApp } from '@/context/app-provider';
 import { useRouter } from 'next/navigation';
@@ -14,6 +15,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Textarea } from '@/components/ui/textarea';
 import { Checkbox } from '@/components/ui/checkbox';
 import type { Property } from '@/lib/types';
+import { uploadImage } from '@/lib/storage';
 
 const formSchema = z.object({
   title: z.string().min(5, "Title must be at least 5 characters"),
@@ -43,6 +45,7 @@ export function PropertyForm({ property }: PropertyFormProps) {
   const router = useRouter();
   const { toast } = useToast();
   const isEditMode = !!property;
+  const [imageFile, setImageFile] = useState<File | null>(null);
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
@@ -70,12 +73,22 @@ export function PropertyForm({ property }: PropertyFormProps) {
     },
   });
 
-  function onSubmit(values: z.infer<typeof formSchema>) {
+  async function onSubmit(values: z.infer<typeof formSchema>) {
+    if (imageFile) {
+      try {
+        const url = await uploadImage(imageFile);
+        values.imageUrl = url;
+        form.setValue('imageUrl', url);
+      } catch (err) {
+        toast({ title: 'Upload failed', description: 'Image could not be uploaded' });
+        return;
+      }
+    }
     if (isEditMode) {
       updateProperty({ ...values, id: property.id });
       toast({ title: 'Property Updated!', description: 'The property details have been saved.' });
     } else {
-      addProperty(values);
+      await addProperty(values);
       toast({ title: 'Property Created!', description: 'The new property has been added to the listings.' });
     }
     router.push('/admin');
@@ -198,6 +211,14 @@ export function PropertyForm({ property }: PropertyFormProps) {
                     <FormMessage />
                 </FormItem>
             )} />
+
+            <FormItem>
+                <FormLabel>Upload Image</FormLabel>
+                <FormControl>
+                    <Input type="file" accept="image/*" onChange={(e) => setImageFile(e.target.files?.[0] || null)} />
+                </FormControl>
+                <FormDescription>The selected image will be uploaded to Firebase</FormDescription>
+            </FormItem>
 
              <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
                 <FormField control={form.control} name="agent.name" render={({ field }) => (

--- a/src/context/app-provider.tsx
+++ b/src/context/app-provider.tsx
@@ -3,13 +3,14 @@
 import React, { createContext, useContext, useState, useMemo, useEffect, ReactNode } from 'react';
 import type { Property, Filters } from '@/lib/types';
 import { mockProperties } from '@/lib/mock-data';
+import { createProperty } from '@/lib/firestore';
 
 const MAX_PRICE = 3000000;
 
 interface AppContextType {
   properties: Property[];
   setProperties: React.Dispatch<React.SetStateAction<Property[]>>;
-  addProperty: (property: Omit<Property, 'id'>) => void;
+  addProperty: (property: Omit<Property, 'id'>) => Promise<void>;
   updateProperty: (property: Property) => void;
   deleteProperty: (id: string) => void;
   role: 'user' | 'admin';
@@ -37,10 +38,11 @@ export function AppProvider({ children }: { children: ReactNode }) {
   const [role, setRole] = useState<'user' | 'admin'>('user');
   const [filters, setFilters] = useState<Filters>(initialFilters);
 
-  const addProperty = (propertyData: Omit<Property, 'id'>) => {
+  const addProperty = async (propertyData: Omit<Property, 'id'>) => {
+    const id = await createProperty(propertyData);
     const newProperty: Property = {
       ...propertyData,
-      id: Date.now().toString(),
+      id,
     };
     setProperties(prev => [newProperty, ...prev]);
   };

--- a/src/lib/firestore.ts
+++ b/src/lib/firestore.ts
@@ -1,0 +1,16 @@
+import { collection, addDoc, doc, setDoc, deleteDoc } from 'firebase/firestore';
+import { db } from './firebase';
+import type { Property } from './types';
+
+export async function createProperty(data: Omit<Property, 'id'>): Promise<string> {
+  const docRef = await addDoc(collection(db, 'properties'), data);
+  return docRef.id;
+}
+
+export async function updatePropertyInDb(id: string, data: Omit<Property, 'id'>): Promise<void> {
+  await setDoc(doc(db, 'properties', id), data);
+}
+
+export async function deletePropertyFromDb(id: string): Promise<void> {
+  await deleteDoc(doc(db, 'properties', id));
+}

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,8 @@
+import { ref, uploadBytes, getDownloadURL } from 'firebase/storage'
+import { storage } from './firebase'
+
+export async function uploadImage(file: File): Promise<string> {
+  const storageRef = ref(storage, `properties/${Date.now()}_${file.name}`)
+  await uploadBytes(storageRef, file)
+  return getDownloadURL(storageRef)
+}


### PR DESCRIPTION
## Summary
- add Firestore helper with create/update/delete utilities
- store new properties in Firestore when submitting the form

## Testing
- `npm run typecheck` *(fails: cannot find module 'react' or corresponding declarations)*
- `npm run lint` *(fails: `next` not found)*
- `npm run test:firebase` *(fails: `tsx` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859dc7086408321aaf537cfd71552df