### PR TITLE
Fix external image config and pass typecheck

### DIFF
--- a/docs/firebase.md
+++ b/docs/firebase.md
@@ -18,6 +18,20 @@ NEXT_PUBLIC_FIREBASE_APP_ID="1:490617761948:web:a1235c3042d041f84a7d59"
 
 3. Ejecuta `npm run test:firebase` para probar la conexión. Si la configuración es correcta, verás en consola cuántas propiedades existen en la colección `properties`.
 
+4. Asegúrate de agregar el dominio de Firebase Storage en `next.config.js` o `next.config.ts` para poder mostrar imágenes externas en los componentes de Next.js:
+
+```js
+images: {
+  remotePatterns: [
+    {
+      protocol: 'https',
+      hostname: 'firebasestorage.googleapis.com',
+      pathname: '/**',
+    },
+  ],
+}
+```
+
 ## Almacenamiento de datos y fotos
 
 - **Firestore**: cada documento en la colección `properties` representa una casa con sus datos principales.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -17,6 +17,12 @@ const nextConfig = {
         port: '',
         pathname: '/**',
       },
+      {
+        protocol: 'https',
+        hostname: 'firebasestorage.googleapis.com',
+        port: '',
+        pathname: '/**',
+      },
     ],
   },
 };

--- a/next.config.ts
+++ b/next.config.ts
@@ -16,6 +16,12 @@ const nextConfig: NextConfig = {
         port: '',
         pathname: '/**',
       },
+      {
+        protocol: 'https',
+        hostname: 'firebasestorage.googleapis.com',
+        port: '',
+        pathname: '/**',
+      },
     ],
   },
 };

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from 'next/link';
-import { Home, Shield, UserSwitch } from 'lucide-react';
+import { Home, Shield } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';


### PR DESCRIPTION
## Summary
- allow `firebasestorage.googleapis.com` in `next.config.*`
- document the Firebase Storage image domain requirement
- remove unused `UserSwitch` import to fix typecheck

## Testing
- `npm run typecheck`
- `npm run build`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_685ad66fdbec832188faa4d66a9695d8