### PR TITLE
Fix Next.js image configuration

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -17,6 +17,12 @@ const nextConfig = {
         port: '',
         pathname: '/**',
       },
+      {
+        protocol: 'https',
+        hostname: 'firebasestorage.googleapis.com',
+        port: '',
+        pathname: '/**',
+      },
     ],
   },
 };


### PR DESCRIPTION
## Summary
- configure `firebasestorage.googleapis.com` as an allowed image host

## Testing
- `npm run typecheck` *(fails: numerous TypeScript errors)*
- `CI=true npm run lint` *(fails: prompts for config)*
- `yes | npx ts-node test-firebase.ts` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_685ada4225d483219cef3108c6954842