### PR TITLE
Fix Next.js build searchParams bug

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/src/app/properties/[id]/page.tsx
+++ b/src/app/properties/[id]/page.tsx
@@ -1,9 +1,10 @@
 'use client';
+export const dynamic = 'force-dynamic';
 
 import { useParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
-import { doc, getDoc, getFirestore } from 'firebase/firestore';
-import { app } from '@/lib/firebase'; // Assuming you have firebase initialized here
+import { doc, getDoc } from 'firebase/firestore';
+import { db } from '@/lib/firebase';
 import type { Property } from '@/lib/types';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import Image from 'next/image';
@@ -17,7 +18,6 @@ export default function PropertyDetailPage() {
   const [property, setProperty] = useState<Property | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const db = getFirestore(app);
 
   useEffect(() => {
     const fetchProperty = async () => {

--- a/test-firebase.ts
+++ b/test-firebase.ts
@@ -1,5 +1,5 @@
 import 'dotenv/config';
-import { db } from '../src/lib/firebase';
+import { db } from './src/lib/firebase';
 import { collection, getDocs } from 'firebase/firestore';
 
 async function run() {


### PR DESCRIPTION
## Summary
- set dynamic rendering for property pages
- correct firebase import path in test script
- add minimal ESLint config to allow linting

## Testing
- `npm run typecheck`
- `CI=true npm run lint` *(fails: ESLint must be installed)*
- `npm run test:firebase`

------
https://chatgpt.com/codex/tasks/task_e_685cb76d2658832193f58f72b5a9b544