### PR TITLE
Switch to admin-only mode

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,26 +1,14 @@
-'use client';
+"use client";
 
-import { Header } from '@/components/header';
-import { PropertyList } from '@/components/property-list';
-import { FilterSidebar } from '@/components/filter-sidebar';
-import { useApp } from '@/context/app-provider';
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
 
 export default function HomePage() {
-  const { filteredProperties } = useApp();
+  const router = useRouter();
 
-  return (
-    <div className="flex flex-col min-h-screen">
-      <Header />
-      <div className="flex-1 w-full container mx-auto p-4 md:p-6">
-        <div className="grid grid-cols-1 md:grid-cols-4 lg:grid-cols-4 gap-6">
-          <aside className="md:col-span-1">
-            <FilterSidebar />
-          </aside>
-          <main className="md:col-span-3">
-            <PropertyList />
-          </main>
-        </div>
-      </div>
-    </div>
-  );
+  useEffect(() => {
+    router.replace("/admin");
+  }, [router]);
+
+  return null;
 }

--- a/src/context/app-provider.tsx
+++ b/src/context/app-provider.tsx
@@ -73,7 +73,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
     };
     fetchProperties();
   }, []);
-  const [role, setRole] = useState<'user' | 'admin'>('user');
+  const [role, setRole] = useState<'user' | 'admin'>('admin');
   const [filters, setFilters] = useState<Filters>(initialFilters);
 
   const addProperty = (propertyData: Omit<Property, 'id'>) => {


### PR DESCRIPTION
## Summary
- redirect homepage to admin dashboard
- default role to admin by default

## Testing
- `npm run lint` *(fails: interactive prompt)*
- `npm run typecheck` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_686b1652d9f48321acd27a264b09b96a